### PR TITLE
Add `n_features_in` to solve bug in sklearn 0.23

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ requirements = {
         "h5py>=2.10.0",
         "pathos>=0.2.5",
         "unidecode>=1.1.1",
-        "inflect>=4.1.0"
+        "inflect>=4.1.0",
+        "scikit-learn>=0.22.0",
     ],
     "setup": [
         "numpy",

--- a/tensorflow_tts/bin/normalize.py
+++ b/tensorflow_tts/bin/normalize.py
@@ -88,6 +88,7 @@ def main():
     if config["format"] == "npy":
         scaler.mean_ = np.load(args.stats)[0]
         scaler.scale_ = np.load(args.stats)[1]
+        scaler.n_features_in_ = config["num_mels"]
     else:
         raise ValueError("Support only npy format")
 


### PR DESCRIPTION
This solves the API change with estimators in scikit-learn [v0.23](https://scikit-learn.org/stable/whats_new/v0.23.html#id4). 
Fixes #40 